### PR TITLE
Allow addition of custom stylesheets and scripts

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,6 +25,8 @@
     {{- partial "opengraph.html" . -}}
     {{- partial "twitter_cards.html" . -}}
     {{ template "_internal/google_analytics.html" . }}
+
+    {{- partial "header.html" . -}}
 </head>
 <body class="terminal">
     <div class="container">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,1 @@
+<!-- Keep - override to add code to <header /> tag -->


### PR DESCRIPTION
This MR allows authors to add custom stylesheets and javascript scripts to the `<header>` tags.

The customization is achieved by overriding the `layouts/partials/header.html` partial that, by default, is empty.

Fixes #3 