### PR TITLE
bugfixed

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@ Console is a minimal, responsive and light theme for Hugo inspired by Linux cons
 
 <div class="posts-list">
 {{ with .Site.GetPage "/posts" }}
-    {{ range first 3 ((where .Pages ".Params.private" "!=" true) sort .Data.Pages "Date" "desc")}}
+    {{ range first 3 (sort (where .Pages ".Params.private" "!=" true) .Data.Pages "Date" "desc")}}
         <div class="post">
             <div class="date">{{ .PublishDate.Format "Jan. 2, 2006" }}</div>    
             <h1><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>


### PR DESCRIPTION
I am using hugo with version `Hugo Static Site Generator v0.72.0-DEV/extended linux/amd64 BuildDate: unknown`

I clone the latest console theme into my site project. After that I create a post with command `hugo new posts/hello-world.md`, then I compile my project with command `hugo -D` without any modification of newly create post. I got error like this:

`Error: Error building site: failed to render pages: render of "home" failed: "/path/to/myblog/site/project/themes/hugo-theme-console/layouts/index.html:14:22": execute of template failed: template: index.html:14:22: executing "main" at <(where .Pages ".Params.private" "!=" true) sort .Data.Pages "Date" "desc">: can't give argument to non-function where .Pages ".Params.private" "!=" true`


I don't know why I got this error and I am not familiar with `hugo template DSL`. Luckily after this modification I got all errors gone.