### PR TITLE
Wraps the front page post summaries in paragraph-tags

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,9 +13,9 @@ Console is a minimal, responsive and light theme for Hugo inspired by Linux cons
 {{ with .Site.GetPage "/posts" }}
     {{ range first 3 (sort .Data.Pages "Date" "desc" (where .Pages ".Params.private" "!=" true))}}
         <div class="post">
-            <div class="date">{{ .PublishDate.Format "Jan. 2, 2006" }}</div>    
+            <p><div class="date">{{ .PublishDate.Format "Jan. 2, 2006" }}</div>    
             <h1><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
-            {{ .Summary }}
+            {{ .Summary }}</p>
         </div>    
     {{ end }}
 {{ end }}


### PR DESCRIPTION
Unless you use `<!--more-->` at the end of a markdown paragraph break (assuming there is one within the summary character limit), the post summaries are stacked together with no vertical whitespace between them. Adding the `<p>`-tags fixes this. The main issue is inconsistency - if the summary ends at a paragraph break then you get the vertical space but it the summary just ends when the character count is full, then there will not be any vertical whitespace. 

Before:
![hugo-1-Screenshot 2020-09-28 103552](https://user-images.githubusercontent.com/1605764/94403763-930fff80-0176-11eb-8f1b-e88cb2b4c4f5.png)

After:
![hugo-2-Screenshot 2020-09-28 103552](https://user-images.githubusercontent.com/1605764/94403779-97d4b380-0176-11eb-9471-4246ddaaa4c0.png)

Similar change should be done to the post-list partial