### PR TITLE
Fix breadcrumb code to follow BreadcrumbList schema

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -39,8 +39,12 @@
               {{ range $index, $element := split $url "/" }}{{ $.Scratch.Add "path" $element }}{{ if ne $element "" }}<a href='{{ $.Scratch.Get "path" | absURL }}'>{{ . }}</a>/{{ $.Scratch.Add "path" "/" }}{{ end }}{{ end }}</div></header>
           <nav class="terminal-menu">
             <ul vocab="https://schema.org/" typeof="BreadcrumbList">
-                {{ range .Site.Params.navlinks }}
-                <li><a href="{{ absURL .url }}" typeof="ListItem">{{ .name }}</a></li>
+                {{ range $index, $element := .Site.Params.navlinks }}
+                <li property="itemListElement" typeof="ListItem">
+                    <a property="item" typeof="WebPage" href="{{ absURL .url }}">
+                    <span property="name">{{ .name }}</span></a>
+                    <meta property="position" content="{{ add $index 1}}" />
+                </li>
                 {{ end }}
             </ul>
           </nav>


### PR DESCRIPTION
This change puts this code in conformance with the schema defined in https://www.schema.org/BreadcrumbList. This fixes validation errors at https://search.google.com/test/rich-results.

This fixes issue #47