### PR TITLE
Bug fix/site title mobile responsiveness

### DIFF
--- a/static/hugo-theme-console/css/console.css
+++ b/static/hugo-theme-console/css/console.css
@@ -251,8 +251,8 @@ figure {
 
 @media only screen and (max-width: 850px) {
     .site-name {
+        width: 2ch;
         overflow: hidden;
-        display: inline-block;
     }
 
     .terminal-nav {

--- a/static/hugo-theme-console/css/console.css
+++ b/static/hugo-theme-console/css/console.css
@@ -251,7 +251,6 @@ figure {
 
 @media only screen and (max-width: 850px) {
     .site-name {
-        width: 2ch;
         overflow: hidden;
         display: inline-block;
     }


### PR DESCRIPTION
When testing my site using this theme using chrome dev extensions in a mobile view, the title kind of gets messed up:

<img width="417" height="708" alt="image" src="https://github.com/user-attachments/assets/1d24e1dc-2eab-4ea4-b994-df0f5fe5fc82" />

I've found that removing the display: inline-block attribute for the .site-name element in console.css fixes this. This is the result:

<img width="584" height="854" alt="image" src="https://github.com/user-attachments/assets/b0d0d61f-c795-4a81-a9da-4970317d7f8e" />
